### PR TITLE
Provide an example of import / export

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -1,0 +1,10 @@
+const HELP = 123;
+
+function helper() {
+    console.log("I'm helping!", HELP);
+}
+
+export function scream() {
+    console.log('aaaaaargh!');
+    helper();
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+import { scream } from './helper.js';
+
+scream();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "safeguarding-rapidpro",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1",
+      "start": "node index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/istride/safeguarding-rapidpro.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/istride/safeguarding-rapidpro/issues"
+  },
+  "homepage": "https://github.com/istride/safeguarding-rapidpro#readme"
+}


### PR DESCRIPTION
The key is to add `"type": "module"` to package.json. Without it, you must use
`require` instead. I think it is better to use the import / export syntax
because it is probably more generally used, allows you to cherry-pick what
you import, and gives more options than `require`.